### PR TITLE
🔀 :: 15 - 예외처리 로직 수정

### DIFF
--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ApolloError } from 'apollo-server-express';
 import { SurveyEntity } from 'src/entities/survey.entity';
@@ -6,6 +6,7 @@ import { Repository } from 'typeorm';
 
 @Injectable()
 export class SurveyService {
+  private readonly logger = new Logger(SurveyService.name);
   constructor(
     @InjectRepository(SurveyEntity)
     private surveyRepository: Repository<SurveyEntity>,
@@ -21,24 +22,24 @@ export class SurveyService {
   }
 
   async updateSurvey(id: number, title: string) {
-    this.checkSurveyIsExist(id);
-    await this.surveyRepository.update({ id: id }, { title: title });
-    return await this.surveyRepository.findOne({ where: { id: id } });
+    await this.checkSurveyExist(id);
+    return await this.surveyRepository.update({ id: id }, { title: title });
   }
 
   async deleteSurvey(id: number) {
-    this.checkSurveyIsExist(id);
+    await this.checkSurveyExist(id);
     await this.surveyRepository.delete({ id: id });
   }
 
-  private async checkSurveyIsExist(id: number) {
+  private async checkSurveyExist(id: number) {
     const existingSurvey = await this.surveyRepository.exist({
       where: { id: id },
     });
     if (!existingSurvey) {
+      this.logger.error(`Survey with ID ${id} not found`, id);
       throw new ApolloError('존재하지 않는 설문지입니다.', 'SURVEY_NOT_FOUND', {
         customErrorCode: 404,
-        pamiteter: 'id',
+        parameter: 'id',
       });
     }
   }


### PR DESCRIPTION
exception handler를 만들려 하였지만 만드는 것보다
```
this.logger.error(`Survey with ID ${id} not found`, id);
      throw new ApolloError('존재하지 않는 설문지입니다.', 'SURVEY_NOT_FOUND', {
        customErrorCode: 404,
        parameter: 'id',
      });
    }
```
이런식의 코드를 작성해서 logging과 예외처리까지 모두 처리되도록 만들 수 있었습니다.