### PR TITLE
🔀:: 53 - 설문지 답변 점수 총합 로직 수정

### DIFF
--- a/src/survey/survey.service.ts
+++ b/src/survey/survey.service.ts
@@ -3,9 +3,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { SurveyEntity } from 'src/entities/survey.entity';
 import { Repository } from 'typeorm';
 import { SurveyUtil } from './utils/survey.util';
-import { QuestionEntity } from 'src/entities/question.entity';
-import { ApolloError } from 'apollo-server-express';
-import { log } from 'console';
 
 @Injectable()
 export class SurveyService {
@@ -36,12 +33,14 @@ export class SurveyService {
       .where('survey.id = :surveyId', { surveyId })
       .getOne();
 
-    console.log(totalScoreQuery.question[0].choice);
-
-    const totalScore = totalScoreQuery.question
-      .flatMap((question) => question.choice)
-      .flatMap((choice) => choice.answer)
-      .reduce((acc, answer) => acc + answer.choice.score, 0);
+    const totalScore = totalScoreQuery.question.reduce((acc, question) => {
+      return (
+        acc +
+        question.choice.reduce((choiceScore, choice) => {
+          return choiceScore + (choice.answer[0] ? choice.score : 0);
+        }, 0)
+      );
+    }, 0);
 
     return totalScore;
   }


### PR DESCRIPTION
설문지 답변 점수의 총합을 구하는 로직을 수정하였습니다.

## 문제상항
```answer.choice.score, 0```
이 코드에서 answer가 접근하는 choice객체가 존재하지 않음
## 해결방법
choice에 answer가 존재하면 choice의 score를 더하도록 수정했습니다.